### PR TITLE
Upstreaming a variety of local changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,6 @@ paket-files/
 *.out
 *.o
 /test
+
+# Gradle
+.gradle/

--- a/Android.bp
+++ b/Android.bp
@@ -19,4 +19,5 @@ cc_library_static {
     export_header_lib_headers: [
         "libjnipp-headers"
     ],
+    vendor_available: true,
 }

--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,22 @@
+
+cc_library_headers {
+    name: "libjnipp-headers",
+    export_include_dirs: ["."],
+    vendor_available: true,
+}
+
+cc_library_static {
+    name: "libjnipp",
+
+    srcs: [
+        "jnipp.cpp",
+    ],
+
+    cppflags: [ "-fexceptions" ],
+    header_libs: [
+        "libjnipp-headers",
+    ],
+    export_header_lib_headers: [
+        "libjnipp-headers"
+    ],
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Java Native Interface for C++
-=============================
+# Java Native Interface for C++
 
 ## Overview
 
@@ -17,9 +16,10 @@ should be implemented - the more likely it is that I will add your feature.
 ## Requirements
 
 To compile you will need:
- - A C++11 compatible compiler
- - An installation of the Java Development Kit (JDK)
- - The `JAVA_HOME` environment variable, directed to your JDK installation.
+
+- A C++11 compatible compiler
+- An installation of the Java Development Kit (JDK)
+- The `JAVA_HOME` environment variable, directed to your JDK installation.
 
 ## Usage
 
@@ -27,8 +27,9 @@ To compile you will need:
 > in the project source code.
 
 There are two situations where the Java Native Interface would be needed.
- - A Java application calling C/C++ functions; or
- - A C/C++ application calling Java methods
+
+- A Java application calling C/C++ functions; or
+- A C/C++ application calling Java methods
 
 ### Calling Java from C++
 
@@ -41,14 +42,14 @@ int main()
 {
     // An instance of the Java VM needs to be created.
     jni::Vm vm;
-	
+
     // Create an instance of java.lang.Integer
     jni::Class Integer = jni::Class("java/lang/Integer");
     jni::Object i = Integer.newInstance("1000");
-	
+
     // Call the `toString` method on that integer
     std::string str = i.call<std::string>("toString");
-	
+
     // The Java VM is automatically destroyed when it goes out of scope.
     return 0;
 }
@@ -69,10 +70,11 @@ class Demo {
         demo.value = 1000;
         demo.run();
     }
-	
+
     public native void run();
 }
 ```
+
 A matching C++ library which uses *jnipp* could look like:
 
 ```C++
@@ -89,10 +91,10 @@ extern "C" void Java_com_example_Demo_run(jni::JNIEnv* env, jni::jobject obj)
 {
     // jnipp only needs initialising once, but it doesn't hurt to do it again.
     jni::init(env);
-	
+
     // Capture the supplied object.
     jni::Object demo(obj);
-	
+
     // Print the contents of the `value` field to stdout.
     std::cout << demo.get<int>("value") << std::endl;
 }

--- a/jnipp.cpp
+++ b/jnipp.cpp
@@ -1480,6 +1480,10 @@ namespace jni
             ((jvalue*) v)->l = env()->NewStringUTF(a);
         }
 
+        void valueArg(value_t* v, std::nullptr_t)
+        {
+            ((jvalue*) v)->l = nullptr;
+        }
 
         template <> void cleanupArg<const char*>(value_t* v)
         {

--- a/jnipp.cpp
+++ b/jnipp.cpp
@@ -615,6 +615,13 @@ namespace jni
         return Class(getClass(), Temporary).getField(name, signature);
     }
 
+    jobject Object::makeLocalReference() const 
+    {
+        if (isNull())
+            return nullptr;
+        return env()->NewLocalRef(_handle);
+    }
+
     /*
         Class Implementation
      */

--- a/jnipp.cpp
+++ b/jnipp.cpp
@@ -243,6 +243,14 @@ namespace jni
         }
     }
 
+    void init(JavaVM* vm) {
+        bool expected = false;
+
+        if (isVm.compare_exchange_strong(expected, true))
+        {
+            javaVm = vm;
+        }
+    }
     /*
         Object Implementation
      */

--- a/jnipp.h
+++ b/jnipp.h
@@ -134,6 +134,7 @@ namespace jni
         void valueArg(value_t* v, const char* a);
         void valueArg(value_t* v, const std::wstring& a);
         void valueArg(value_t* v, const wchar_t* a);
+        void valueArg(value_t* v, std::nullptr_t);
 
         inline void args(value_t*) {}
 

--- a/jnipp.h
+++ b/jnipp.h
@@ -138,7 +138,7 @@ namespace jni
             internal::args(values + 1, args...);
         }
 
-        template <class TArg> void cleanupArg(value_t* value) {}
+        template <class TArg> void cleanupArg(value_t* /* value */) {}
         template <>           void cleanupArg<std::string>(value_t* value);
         template <>           void cleanupArg<std::wstring>(value_t* value);
         template <>           void cleanupArg<const char*>(value_t* value);
@@ -151,7 +151,7 @@ namespace jni
         }
 
         template <>
-        inline void cleanupArgs<void>(value_t* values) {}
+        inline void cleanupArgs<void>(value_t* /* values */) {}
 
         template <class... TArgs>
         class ArgArray

--- a/jnipp.h
+++ b/jnipp.h
@@ -465,6 +465,18 @@ namespace jni
         field_t getField(const char* name, const char* signature) const;
 
         /**
+            Gets a handle to the field with the given name and the supplied type.
+            This handle can then be stored so that the field does not need to
+            be looked up by name again. It does not need to be deleted.
+            \param name The name of the field.
+            \return The field ID.
+         */
+        template<typename TType>
+        field_t getField(const char* name) const {
+            return getField(name, internal::valueSig((TType*) nullptr).c_str());
+        }
+
+        /**
             Gets a handle to the static field with the given name and type signature.
             This handle can then be stored so that the field does not need to
             be looked up by name again. It does not need to be deleted.

--- a/jnipp.h
+++ b/jnipp.h
@@ -515,6 +515,18 @@ namespace jni
         field_t getStaticField(const char* name, const char* signature) const;
 
         /**
+            Gets a handle to the static field with the given name and the supplied type.
+            This handle can then be stored so that the field does not need to
+            be looked up by name again. It does not need to be deleted.
+            \param name The name of the field.
+            \return The field ID.
+         */
+        template<typename TType>
+        field_t getStaticField(const char* name) const {
+            return getStaticField(name, internal::valueSig((TType*)nullptr).c_str());
+        }
+
+        /**
             Gets a handle to the method with the given name and signature.
             This handle can then be stored so that the method does not need
             to be looked up by name again. It does not need to be deleted.

--- a/jnipp.h
+++ b/jnipp.h
@@ -393,6 +393,12 @@ namespace jni
          */
         jobject getHandle() const noexcept { return _handle; }
 
+        /**
+            Create a local reference for the underlying JNI handle.
+            \return The local reference.
+         */
+        jobject makeLocalReference() const;
+
     private:
         // Helper Functions
         method_t getMethod(const char* name, const char* signature) const;

--- a/jnipp.h
+++ b/jnipp.h
@@ -193,6 +193,11 @@ namespace jni
     void init(JavaVM* vm);
 
     /**
+        Get the appropriate JNI environment for this thread.
+     */
+    JNIEnv* env();
+
+    /**
         Object corresponds with a `java.lang.Object` instance. With an Object,
         you can then call Java methods, and access fields on the Object. To
         instantiate an Object of a given class, use the `Class` class.

--- a/jnipp.h
+++ b/jnipp.h
@@ -9,6 +9,8 @@
 // Forward Declarations
 struct JNIEnv_;
 struct _JNIEnv;
+struct JavaVM_;
+struct _JavaVM;
 struct _jmethodID;
 struct _jfieldID;
 class  _jobject;
@@ -20,9 +22,12 @@ namespace jni
     // JNI Base Types
 #ifdef __ANDROID__
     typedef _JNIEnv     JNIEnv;
+    typedef _JavaVM JavaVM;
 #else
     typedef JNIEnv_     JNIEnv;
+    typedef JavaVM_ JavaVM;
 #endif
+
     typedef _jobject* jobject;
     typedef _jclass* jclass;
     typedef _jarray* jarray;
@@ -179,6 +184,13 @@ namespace jni
         \param env A JNI environment handle.
      */
     void init(JNIEnv* env);
+    /**
+        Initialises the Java Native Interface with the given JavaVM handle,
+        which may be accessible. This (or the other overload) only needs to be
+        done once per process - further calls are no-ops.
+        \param vm A JNI VM handle.
+     */
+    void init(JavaVM* vm);
 
     /**
         Object corresponds with a `java.lang.Object` instance. With an Object,
@@ -401,6 +413,11 @@ namespace jni
     class Class : protected Object
     {
     public:
+        /**
+            Creates a null class reference.
+         */
+        Class() : Object() {}
+
         /**
             Obtains a class reference to the Java class with the given qualified
             name.

--- a/makefile
+++ b/makefile
@@ -11,7 +11,9 @@ else
   endif
 endif
 
-CXXFLAGS=-I. -I${JAVA_HOME}/include -I${JAVA_HOME}/include/$(OS_NAME) -ldl -std=c++11
+JAVA_HOME ?= /usr/lib/jvm/default-java
+
+CXXFLAGS=-I. -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(OS_NAME) -ldl -std=c++11
 
 SRC=jnipp.o main.o
 VPATH=tests

--- a/makefile
+++ b/makefile
@@ -4,7 +4,9 @@ OS_NAME := linux
 
 ifeq ($(OS),Windows_NT)
   OS_NAME := win32
+  RM := del
 else
+  RM := rm -f
   UNAME_S := $(shell uname -s)
   ifeq ($(UNAME_S),Darwin)
     OS_NAME := darwin
@@ -24,3 +26,7 @@ VPATH=tests
 test: $(SRC)
 	$(CC) -o test $(SRC) $(CXXFLAGS)
 
+clean:
+	-$(RM) $(SRC) test
+
+.PHONY: clean

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -295,6 +295,19 @@ TEST(Object_call_byNameWithArgs)
     ASSERT(str2.call<wchar_t>("charAt", 1) == L'e');
 }
 
+TEST(Object_makeLocalReference)
+{
+    jni::Object str = jni::Class("java/lang/String").newInstance("Testing");
+
+    jni::jobject local = str.makeLocalReference();
+    ASSERT(local != nullptr);
+    ASSERT(local != str.getHandle());
+
+    jni::Object fromLocal(local, jni::Object::DeleteLocalInput);
+    ASSERT(!fromLocal.isNull());
+    ASSERT(str == fromLocal);
+}
+
 /*
     jni::Enum Tests
  */
@@ -570,6 +583,7 @@ int main()
         RUN_TEST(Object_call_byName);
         RUN_TEST(Object_call_withArgs);
         RUN_TEST(Object_call_byNameWithArgs);
+        RUN_TEST(Object_makeLocalReference);
 
         // jni::Enum Tests
         RUN_TEST(Enum_get);


### PR DESCRIPTION
Thanks for this library, it's really nice! As I've been using it, I found a few little holes/gaps I wanted to suggest filling. Not sure if you want all the changes in one branch like this, or if I should submit each commit individually - let me know.

brief "why" of various changes:

- Android.bp - so it can be used in an Android AOSP (ROM) build
- templated getField - just a missing functionality - could get a field value directly with templated, but for getting the field ID you had to manually do the type/signature conversion.
- Init free function taking JavaVM directly - sometimes APIs provide the JavaVM instead of the env, and it was simplest just to expose this capability that was already essentially there.
- makeLocalReference: To be able to return something from a jni-invoked function, the local reference will transfer to the caller.
- Expose the env() function - sometimes I can't quite get everything I need from jnipp so this is an "escape hatch"

I added a test where I could, but I couldn't find a "always-there" class guaranteed to have a non-static field to add a getField test.