### PR TITLE
Upstreaming3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright 2021, Collabora, Ltd.
+#
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.10.2)
+project(jnipp)
+
+find_package(JNI REQUIRED)
+include(CTest)
+
+add_library(jnipp jnipp.cpp)
+target_include_directories(
+  jnipp
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${JNI_INCLUDE_DIRS})
+target_link_libraries(jnipp PUBLIC ${CMAKE_DL_LIBS})
+
+add_subdirectory(tests)

--- a/jnipp.cpp
+++ b/jnipp.cpp
@@ -26,9 +26,13 @@ namespace jni
     static std::atomic_bool isVm(false);
     static JavaVM* javaVm = nullptr;
 
+    static bool getEnv(JavaVM *vm, JNIEnv **env) {
+        return vm->GetEnv((void **)env, JNI_VERSION_1_2) == JNI_OK;
+    }
+
     static bool isAttached(JavaVM *vm) {
         JNIEnv *env = nullptr;
-        return vm->GetEnv((void **)&env, JNI_VERSION_1_2) == JNI_OK;
+        return getEnv(vm, &env);
     }
     /**
         Maintains the lifecycle of a JNIEnv.
@@ -63,7 +67,7 @@ namespace jni
         if (vm == nullptr)
             throw InitializationException("JNI not initialized");
 
-        if (!isAttached(vm))
+        if (!getEnv(vm, &_env))
         {
 #ifdef __ANDROID__
             if (vm->AttachCurrentThread(&_env, nullptr) != 0)

--- a/jnipp.cpp
+++ b/jnipp.cpp
@@ -368,20 +368,20 @@ namespace jni
         return _handle == nullptr || env()->IsSameObject(_handle, nullptr);
     }
 
-    template <> void Object::callMethod(method_t method, internal::value_t* args) const
+    void Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<void> const&) const
     {
         env()->CallVoidMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
     }
 
-    template <> bool Object::callMethod(method_t method, internal::value_t* args) const
+    bool Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<bool> const&) const
     {
         auto result = env()->CallBooleanMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return result != 0;
     }
 
-    template <> bool Object::get(field_t field) const
+    bool Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<bool> const&) const
     {
         return env()->GetBooleanField(_handle, field) != 0;
     }
@@ -391,122 +391,122 @@ namespace jni
         env()->SetBooleanField(_handle, field, value);
     }
 
-    template <> byte_t Object::callMethod(method_t method, internal::value_t* args) const
+    byte_t Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<byte_t> const&) const
     {
         auto result = env()->CallByteMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return result;
     }
 
-    template <> wchar_t Object::callMethod(method_t method, internal::value_t* args) const
+    wchar_t Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<wchar_t> const&) const
     {
         auto result = env()->CallCharMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return result;
     }
 
-    template <> short Object::callMethod(method_t method, internal::value_t* args) const
+    short Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<short> const&) const
     {
         auto result = env()->CallShortMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return result;
     }
 
-    template <> int Object::callMethod(method_t method, internal::value_t* args) const
+    int Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<int> const&) const
     {
         auto result = env()->CallIntMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return result;
     }
 
-    template <> long long Object::callMethod(method_t method, internal::value_t* args) const
+    long long Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<long long> const&) const
     {
         auto result = env()->CallLongMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return result;
     }
 
-    template <> float Object::callMethod(method_t method, internal::value_t* args) const
+    float Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<float> const&) const
     {
         auto result = env()->CallFloatMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return result;
     }
 
-    template <> double Object::callMethod(method_t method, internal::value_t* args) const
+    double Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<double> const&) const
     {
         auto result = env()->CallDoubleMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return result;
     }
 
-    template <> std::string Object::callMethod(method_t method, internal::value_t* args) const
+    std::string Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<std::string> const&) const
     {
         auto result = env()->CallObjectMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return toString(result);
     }
 
-    template <> std::wstring Object::callMethod(method_t method, internal::value_t* args) const
+    std::wstring Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<std::wstring> const&) const
     {
         auto result = env()->CallObjectMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return toWString(result);
     }
 
-    template <> jni::Object Object::callMethod(method_t method, internal::value_t* args) const
+    jni::Object Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<jni::Object> const&) const
     {
         auto result = env()->CallObjectMethodA(_handle, method, (jvalue*) args);
         handleJavaExceptions();
         return Object(result, DeleteLocalInput);
     }
 
-    template <> byte_t Object::get(field_t field) const
+    byte_t Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<byte_t> const&) const
     {
         return env()->GetByteField(_handle, field);
     }
 
-    template <> wchar_t Object::get(field_t field) const
+    wchar_t Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<wchar_t> const&) const
     {
         return env()->GetCharField(_handle, field);
     }
 
-    template <> short Object::get(field_t field) const
+    short Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<short> const&) const
     {
         return env()->GetShortField(_handle, field);
     }
 
-    template <> int Object::get(field_t field) const
+    int Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<int> const&) const
     {
         return env()->GetIntField(_handle, field);
     }
 
-    template <> long long Object::get(field_t field) const
+    long long Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<long long> const&) const
     {
         return env()->GetLongField(_handle, field);
     }
 
-    template <> float Object::get(field_t field) const
+    float Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<float> const&) const
     {
         return env()->GetFloatField(_handle, field);
     }
 
-    template <> double Object::get(field_t field) const
+    double Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<double> const&) const
     {
         return env()->GetDoubleField(_handle, field);
     }
 
-    template <> std::string Object::get(field_t field) const
+    std::string Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<std::string> const&) const
     {
         return toString(env()->GetObjectField(_handle, field));
     }
 
-    template <> std::wstring Object::get(field_t field) const
+    std::wstring Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<std::wstring> const&) const
     {
         return toWString(env()->GetObjectField(_handle, field));
     }
 
-    template <> Object Object::get(field_t field) const
+    Object Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<Object> const&) const
     {
         return Object(env()->GetObjectField(_handle, field), DeleteLocalInput);
     }

--- a/jnipp.cpp
+++ b/jnipp.cpp
@@ -6,6 +6,8 @@
 #else
   // UNIX Dependencies
 # include <dlfcn.h>
+# include <unistd.h>
+# include <tuple>
 #endif
 
 // External Dependencies
@@ -1270,7 +1272,57 @@ namespace jni
 
     typedef jint (JNICALL *CreateVm_t)(JavaVM**, void**, void*);
 
+#ifndef _WIN32
+    static bool fileExists(const std::string& filePath)
+    {
+        return access(filePath.c_str(), F_OK) != -1;
+    }
 
+    template <size_t N>
+    static ssize_t readlink_safe(const char *pathname, char (&output)[N]) {
+        auto len = readlink(pathname, output, N - 1);
+        if (len > 0) {
+            output[len] = '\0';
+        }
+        return len;
+    }
+
+    static std::pair<ssize_t, std::string>
+    readlink_as_string(const char *pathname) {
+        char buf[2048] = {};
+        auto len = readlink_safe(pathname, buf);
+        if (len <= 0) {
+            return {len, {}};
+        }
+        return {len, std::string{buf, static_cast<size_t>(len)}};
+    }
+    static std::string readlink_deep(const char *pathname) {
+        std::string prev{pathname};
+        ssize_t len = 0;
+        std::string next;
+        while (true) {
+            std::tie(len, next) = readlink_as_string(prev.c_str());
+            if (!next.empty()) {
+                prev = next;
+            } else {
+                return prev;
+            }
+        }
+    }
+
+    static std::string drop_path_components(const std::string & path, size_t num_components) {
+        size_t pos = std::string::npos;
+        size_t slash_pos = std::string::npos;
+        for (size_t i = 0; i < num_components; ++i) {
+            slash_pos = path.find_last_of('/', pos);
+            if (slash_pos == std::string::npos || slash_pos == 0) {
+                return {};
+            }
+            pos = slash_pos - 1;
+        }
+        return std::string{path.c_str(), slash_pos};
+    }
+#endif
     static std::string detectJvmPath()
     {
         std::string result;
@@ -1321,7 +1373,7 @@ namespace jni
                     javaHome + "\\bin\\server\\jvm.dll"
                 };
 
-                for (auto i : options)
+                for (auto const& i : options)
                     if (fileExists(i))
                         return i;
             }
@@ -1338,6 +1390,28 @@ namespace jni
             #endif
             result = libJvmPath;
         } else {
+            std::string path = readlink_deep("/usr/bin/java");
+            if (!path.empty()) {
+                // drop bin and java
+                auto javaHome = drop_path_components(path, 2);
+                if (!javaHome.empty()) {
+                    std::string options[] = {
+                        javaHome + "/jre/lib/amd64/server/libjvm.so",
+                        javaHome + "/jre/lib/amd64/client/libjvm.so",
+                        javaHome + "/jre/lib/server/libjvm.so",
+                        javaHome + "/jre/lib/client/libjvm.so",
+                        javaHome + "/lib/server/libjvm.so",
+                        javaHome + "/lib/client/libjvm.so",
+                    };
+
+                    for (auto const &i : options) {
+                        fprintf(stderr, "trying %s\n", i.c_str());
+                        if (fileExists(i)) {
+                            return i;
+                        }
+                    }
+                }
+            }
             // Best guess so far.
             result = "/usr/lib/jvm/default-java/jre/lib/amd64/server/libjvm.so";
         }

--- a/jnipp.h
+++ b/jnipp.h
@@ -190,6 +190,17 @@ namespace jni
             value_t values[1];
         };
         long getArrayLength(jarray array);
+
+        /**
+         * @brief Used as a tag type for dispatching internally based on return type.
+         *
+         * @tparam T The type to wrap.
+         */
+        template<typename T>
+        struct ReturnTypeWrapper
+        {
+            using type = T;
+        };
     }
 
     /**
@@ -296,7 +307,7 @@ namespace jni
             \return The method's return value.
          */
         template <class TReturn>
-        TReturn call(method_t method) const { return callMethod<TReturn>(method, nullptr); }
+        TReturn call(method_t method) const { return callMethod(method, nullptr, internal::ReturnTypeWrapper<TReturn>{}); }
 
         /**
             Calls the method on this Object with the given name, and no arguments.
@@ -326,7 +337,7 @@ namespace jni
         template <class TReturn, class... TArgs>
         TReturn call(method_t method, const TArgs&... args) const {
             internal::ArgArray<TArgs...> transform(args...);
-            return callMethod<TReturn>(method, transform.values);
+            return callMethod(method, transform.values, internal::ReturnTypeWrapper<TReturn>{});
         }
 
         /**
@@ -356,7 +367,11 @@ namespace jni
             \return The field's value.
          */
         template <class TType>
-        TType get(field_t field) const;
+        TType get(field_t field) const {
+            // If you get a compile error here, then you've asked for a type
+            // we don't know how to get from JNI directly.
+            return getFieldValue(field, internal::ReturnTypeWrapper<TType>{});
+        }
 
         /**
             Gets a field value from this Object. The field must belong to the
@@ -424,7 +439,33 @@ namespace jni
         method_t getMethod(const char* name, const char* signature) const;
         method_t getMethod(const char* nameAndSignature) const;
         field_t getField(const char* name, const char* signature) const;
-        template <class TType> TType callMethod(method_t method, internal::value_t* values) const;
+
+        void callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<void> const&) const;
+        bool callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<bool> const&) const;
+        byte_t callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<byte_t> const&) const;
+        wchar_t callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<wchar_t> const&) const;
+        short callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<short> const&) const;
+        int callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<int> const&) const;
+        long long callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<long long> const&) const;
+        float callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<float> const&) const;
+        double callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<double> const&) const;
+        std::string callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<std::string> const&) const;
+        std::wstring callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<std::wstring> const&) const;
+        jni::Object callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<jni::Object> const&) const;
+
+
+        void getFieldValue(field_t field, internal::ReturnTypeWrapper<void> const&) const;
+        bool getFieldValue(field_t field, internal::ReturnTypeWrapper<bool> const&) const;
+        byte_t getFieldValue(field_t field, internal::ReturnTypeWrapper<byte_t> const&) const;
+        wchar_t getFieldValue(field_t field, internal::ReturnTypeWrapper<wchar_t> const&) const;
+        short getFieldValue(field_t field, internal::ReturnTypeWrapper<short> const&) const;
+        int getFieldValue(field_t field, internal::ReturnTypeWrapper<int> const&) const;
+        long long getFieldValue(field_t field, internal::ReturnTypeWrapper<long long> const&) const;
+        float getFieldValue(field_t field, internal::ReturnTypeWrapper<float> const&) const;
+        double getFieldValue(field_t field, internal::ReturnTypeWrapper<double> const&) const;
+        std::string getFieldValue(field_t field, internal::ReturnTypeWrapper<std::string> const&) const;
+        std::wstring getFieldValue(field_t field, internal::ReturnTypeWrapper<std::wstring> const&) const;
+        jni::Object getFieldValue(field_t field, internal::ReturnTypeWrapper<jni::Object> const&) const;
 
         // Instance Variables
         jobject _handle;

--- a/jnipp.h
+++ b/jnipp.h
@@ -175,6 +175,20 @@ namespace jni
             value_t values[sizeof...(TArgs)];
         };
 
+        /* specialization for empty array - no args. Avoids "empty array" warning. */
+        template <>
+        class ArgArray<>
+        {
+        public:
+            ArgArray() {
+                std::memset(this, 0, sizeof(ArgArray<>));
+            }
+
+            ~ArgArray() {
+            }
+
+            value_t values[1];
+        };
         long getArrayLength(jarray array);
     }
 

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ endif
 
 JAVA_HOME ?= /usr/lib/jvm/default-java
 
-CXXFLAGS=-I. -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(OS_NAME) -ldl -std=c++11
+CXXFLAGS=-I. -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(OS_NAME) -ldl -std=c++11 -Wall -g
 
 SRC=jnipp.o main.o
 VPATH=tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright 2021, Collabora, Ltd.
+#
+# SPDX-License-Identifier: MIT
+
+add_executable(main_test main.cpp testing.h)
+target_link_libraries(main_test PRIVATE jnipp)
+add_test(NAME main_test COMMAND main_test)
+
+add_executable(external_create external_create.cpp testing.h)
+target_link_libraries(external_create PUBLIC jnipp ${JNI_LIBRARIES})
+target_include_directories(external_create PUBLIC ${JNI_INCLUDE_DIRS})
+add_test(NAME external_create COMMAND external_create)
+
+
+add_executable(external_detach external_detach.cpp testing.h)
+target_link_libraries(external_detach PUBLIC jnipp ${JNI_LIBRARIES})
+target_include_directories(external_detach PUBLIC ${JNI_INCLUDE_DIRS})
+add_test(NAME external_detach COMMAND external_detach)

--- a/tests/external_create.cpp
+++ b/tests/external_create.cpp
@@ -1,0 +1,37 @@
+// Project Dependencies
+#include <jni.h>
+#include <jnipp.h>
+
+// Standard Dependencies
+#include <cmath>
+
+// Local Dependencies
+#include "testing.h"
+
+/*
+    jni::Vm Tests
+ */
+TEST(Vm_externalCreateAndAttach) {
+    JNIEnv *env;
+    JavaVMInitArgs args = {};
+    args.version = JNI_VERSION_1_2;
+    JavaVM *javaVm{};
+    auto ret = JNI_CreateJavaVM(&javaVm, (void **)&env, &args);
+    ASSERT(ret == 0);
+
+    {
+        jni::init(env);
+        jni::Class cls("java/lang/String");
+    }
+    JavaVM *localVmPointer{};
+
+    ret = env->GetJavaVM(&localVmPointer);
+    ASSERT(ret == 0);
+}
+
+int main() {
+    // jni::Vm Tests
+    RUN_TEST(Vm_externalCreateAndAttach);
+
+    return 0;
+}

--- a/tests/external_detach.cpp
+++ b/tests/external_detach.cpp
@@ -1,0 +1,34 @@
+// Project Dependencies
+#include <jni.h>
+#include <jnipp.h>
+
+// Standard Dependencies
+#include <cmath>
+
+// Local Dependencies
+#include "testing.h"
+
+/*
+    jni::Vm Tests
+ */
+TEST(Vm_externalDetach) {
+    jni::Vm vm;
+
+    jni::Class cls("java/lang/String");
+
+    JNIEnv *env = (JNIEnv *)jni::env();
+    JavaVM *localVmPointer{};
+
+    auto ret = env->GetJavaVM(&localVmPointer);
+    ASSERT(ret == 0);
+    ret = localVmPointer->DetachCurrentThread();
+    ASSERT(ret == 0);
+
+    ASSERT(1);
+}
+
+int main() {
+    // jni::Vm Tests
+    RUN_TEST(Vm_externalDetach);
+    return 0;
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -622,8 +622,6 @@ int main()
         RUN_TEST(Arg_ObjectPtr);
     }
 
-    std::cout << "Press a key to continue..." << std::endl;
-    std::cin.get();
     return 0;
 }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -249,6 +249,15 @@ TEST(Object_moveAssignmentOperator)
     ASSERT(b.isNull());
 }
 
+TEST(Object_nullary_construct_from_signature)
+{
+    jni::Class String("java/lang/String");
+    jni::method_t init = String.getMethod("<init>", "()V");
+    jni::Object i = String.newInstance(init);
+    ASSERT(!i.isNull());
+    jni::internal::ArgArray<> a;
+}
+
 TEST(Object_call)
 {
     jni::Class Integer("java/lang/Integer");
@@ -575,6 +584,7 @@ int main()
 
         // jni::Object Tests
         RUN_TEST(Object_defaultConstructor_isNull);
+        RUN_TEST(Object_nullary_construct_from_signature);
         RUN_TEST(Object_copyConstructorIsSameObject);
         RUN_TEST(Object_moveConstructor);
         RUN_TEST(Object_copyAssignmentOperator);


### PR DESCRIPTION
A couple of fixes here, some are particularly important if you're using jnipp in a library (like the OpenXR loader) and thus don't have 100% control over when the thread gets attached/detached.