### PR TITLE
Introduce a no-exceptions mode to JNIPP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,24 @@ project(jnipp)
 find_package(JNI REQUIRED)
 include(CTest)
 
+option(
+    JNIPP_USE_EXCEPTION_HANDLING
+    "Enable exception handling in JNIPP."
+    ON
+)
+
 add_library(jnipp jnipp.cpp)
+
+if(NOT JNIPP_USE_EXCEPTION_HANDLING)
+  target_compile_definitions(jnipp PUBLIC JNIPP_USE_EXCEPTION=0)
+
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(jnipp PRIVATE -fno-exceptions)
+  endif()
+else()
+  target_compile_definitions(jnipp PUBLIC JNIPP_USE_EXCEPTION=1)
+endif()
+
 target_include_directories(
   jnipp
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ extern "C" void Java_com_example_Demo_run(jni::JNIEnv* env, jni::jobject obj)
 
 ## Configuration
 
-By default, *jnipp* uses std::runtime_error as the base exception class. If you wish,
+By default, *jnipp* uses `std::runtime_error` as the base exception class. If you wish,
 you can define `JNIPP_EXCEPTION_CLASS` to be the exception class you wish to use, before
 including `jnipp.h`. It just needs a `const char*` constructor.
+
+### Disabling exceptions
+
+*jnipp* supports a no-exception mode, in which all `throw` expressions will be replaced with calls to `std::terminate()`. It can be enabled by compiling the library with `JNIPP_USE_EXCEPTION` defined to value `0`. This is also controlled by the CMake option called `JNIPP_USE_EXCEPTION_HANDLING`, which is `ON` by default (i.e. exceptions will by default be *enabled*).

--- a/jnipp.cpp
+++ b/jnipp.cpp
@@ -21,9 +21,9 @@
 #include "jnipp.h"
 
 #if JNIPP_USE_EXCEPTION
+#include <exception>
 #define JNIPP_THROW(...) do { throw __VA_ARGS__; } while(0)
 #else
-#include <exception>
 #define JNIPP_THROW(...) do { std::terminate(); } while(0)
 #endif
 

--- a/jnipp.h
+++ b/jnipp.h
@@ -3,8 +3,15 @@
 
 // Standard Dependencies
 #include <cstring>
-#include <stdexcept>        // For std::runtime_error
 #include <string>
+
+#ifndef JNIPP_USE_EXCEPTION
+#error "JNIPP_USE_EXCEPTION not defined"
+#endif
+
+#if JNIPP_USE_EXCEPTION
+#include <stdexcept>        // For std::runtime_error
+#endif
 
 // Forward Declarations
 struct JNIEnv_;
@@ -55,6 +62,7 @@ namespace jni
      */
     typedef unsigned char byte_t;
 
+#if JNIPP_USE_EXCEPTION
 #ifdef JNIPP_EXCEPTION_CLASS
 
     /**
@@ -70,6 +78,7 @@ namespace jni
     typedef std::runtime_error Exception;
 
 #endif // JNIPP_EXCEPTION_CLASS
+#endif  // JNIPP_USE_EXCEPTION
 
     // Foward Declarations
     class Object;
@@ -986,6 +995,7 @@ namespace jni
         ~Vm();
     };
 
+#if JNIPP_USE_EXCEPTION
     /**
         A Java method call threw an Exception.
      */
@@ -1024,6 +1034,7 @@ namespace jni
          */
         InitializationException(const char* msg) : Exception(msg) {}
     };
+#endif
 
     /*
         Array Implementation

--- a/jnipp.h
+++ b/jnipp.h
@@ -5,8 +5,11 @@
 #include <cstring>
 #include <string>
 
+// JNIPP by default uses exceptions to communicate errors to the consumers.
+// The preprocessor directive should be set by the build script, but in case
+// it wasn't, define it here to its expected default value.
 #ifndef JNIPP_USE_EXCEPTION
-#error "JNIPP_USE_EXCEPTION not defined"
+#define JNIPP_USE_EXCEPTION 1
 #endif
 
 #if JNIPP_USE_EXCEPTION

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,12 @@ add_executable(main_test main.cpp testing.h)
 target_link_libraries(main_test PRIVATE jnipp)
 add_test(NAME main_test COMMAND main_test)
 
+if(NOT JNIPP_USE_EXCEPTION_HANDLING)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(main_test PRIVATE -fno-exceptions)
+  endif()
+endif()
+
 add_executable(external_create external_create.cpp testing.h)
 target_link_libraries(external_create PUBLIC jnipp ${JNI_LIBRARIES})
 target_include_directories(external_create PUBLIC ${JNI_INCLUDE_DIRS})

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -11,7 +11,7 @@
     jni::Vm Tests
  */
 
-
+#if JNIPP_USE_EXCEPTION == 1
 TEST(Vm_detectsJreInstall)
 {
     try
@@ -42,6 +42,7 @@ TEST(Vm_notAllowedMultipleVms)
 
     ASSERT(0);
 }
+#endif
 
 /*
     jni::Class Tests
@@ -55,6 +56,7 @@ TEST(Class_findByName_success)
     ASSERT(!cls.isNull());
 }
 
+#if JNIPP_USE_EXCEPTION
 TEST(Class_findByName_failure)
 {
     try
@@ -69,6 +71,7 @@ TEST(Class_findByName_failure)
 
     ASSERT(0);
 }
+#endif
 
 TEST(Class_getName)
 {
@@ -430,6 +433,7 @@ TEST(Array_getElement_defaultValue)
     ASSERT(s.getElement(0).length() == 0);
 }
 
+#if JNIPP_USE_EXCEPTION
 TEST(Array_getElement_indexException)
 {
     jni::Array<int> a(10);
@@ -444,6 +448,7 @@ TEST(Array_getElement_indexException)
         ASSERT(1);
     }
 }
+#endif
 
 TEST(Array_setElement_basicType)
 {
@@ -467,6 +472,7 @@ TEST(Array_setElement_string)
         ASSERT(a.getElement(i) == std::to_wstring(i));
 }
 
+#if JNIPP_USE_EXCEPTION
 TEST(Array_setElement_indexException)
 {
     jni::Array<std::string> s(10);
@@ -481,6 +487,7 @@ TEST(Array_setElement_indexException)
         ASSERT(1);
     }
 }
+#endif
 
 /*
     Argument Type Tests
@@ -560,15 +567,20 @@ TEST(Arg_ObjectPtr)
 int main()
 {
     // jni::Vm Tests
+
+#if JNIPP_USE_EXCEPTION
     RUN_TEST(Vm_detectsJreInstall);
     RUN_TEST(Vm_notAllowedMultipleVms);
+#endif
 
     {
         jni::Vm vm;
 
         // jni::Class Tests
         RUN_TEST(Class_findByName_success);
+#if JNIPP_USE_EXCEPTION
         RUN_TEST(Class_findByName_failure);
+#endif
         RUN_TEST(Class_getName);
         RUN_TEST(Class_getParent);
         RUN_TEST(Class_newInstance);
@@ -606,10 +618,14 @@ int main()
         RUN_TEST(Array_copyConstructor);
         RUN_TEST(Array_moveConstructor);
         RUN_TEST(Array_getElement_defaultValue);
+#if JNIPP_USE_EXCEPTION
         RUN_TEST(Array_getElement_indexException);
+#endif
         RUN_TEST(Array_setElement_basicType);
         RUN_TEST(Array_setElement_string);
+#if JNIPP_USE_EXCEPTION
         RUN_TEST(Array_setElement_indexException);
+#endif
 
         // Argument Type Tests
         RUN_TEST(Arg_bool);


### PR DESCRIPTION
This PR introduces a no-exceptions mode to JNIPP. Some of the downstream consumers of JNIPP are meant to be built with exceptions disabled, but that becomes a bit problematic when their direct or indirect dependency does not support such mode.

Changes:
- introduce new CMake option, `JNIPP_USE_EXCEPTION_HANDLING`, ON by default
- introduce preprocessor directive, `JNIPP_USE_EXCEPTION`, in `jnipp.h` header (set to `1` by default)
- when `JNIPP_USE_EXCEPTION` is set to `0`, all `throw` exceptions in `jnipp.cpp` will be replaced by calls to `std::terminate()`; this is achieved via a cpp-only macro, `JNIPP_THROW`
- test cases that rely on exceptions being thrown are not compiled at all if JNIPP is compiled with exceptions support turned off
- when built without exceptions on Clang and GCC, both the library and the tests will be compiled with `-fno-exceptions` switch

Tested as follows:
1. Exceptions mode:
```
cmake -S . -B out/exceptions -G Ninja -DJNIPP_USE_EXCEPTION_HANDLING=ON
cmake --build out/exceptions/
ctest --test-dir out/exceptions/
```

2. No-exceptions mode:
```
cmake -S . -B out/no-exceptions -G Ninja -DJNIPP_USE_EXCEPTION_HANDLING=OFF
cmake --build out/no-exceptions/
ctest --test-dir out/no-exceptions/
```