### PR TITLE
Stop using std::basic_string<unsigned short>

### DIFF
--- a/changes/changes/pr.40.md
+++ b/changes/changes/pr.40.md
@@ -1,0 +1,1 @@
+Stop using `std::basic_string<jchar>` internally, because it is `std::basic_string<unsigned short>` on some platforms, and this specialization is not technically provided by the standard library. libc++ is removing support for it, so this internal change is required to continue to compile against libc++. In place of it, use `std::vector<jchar>`.

--- a/jnipp.cpp
+++ b/jnipp.cpp
@@ -16,6 +16,7 @@
 // Standard Dependencies
 #include <atomic>
 #include <string>
+#include <vector>
 
 // Local Dependencies
 #include "jnipp.h"
@@ -129,9 +130,9 @@ namespace jni
     /**
         Convert from a UTF-32 string to a UTF-16 Java string.
      */
-    std::basic_string<jchar> toJString(const wchar_t* str, size_t length)
+    std::vector<jchar> toJString(const wchar_t* str, size_t length)
     {
-        std::basic_string<jchar> result;
+        std::vector<jchar> result;
 
         result.reserve(length * 2);    // Worst case scenario.
 
@@ -144,11 +145,11 @@ namespace jni
                 ch -= uint32_t(0x10000);
 
                 // Add the first of the two-segment character.
-                result += jchar(0xD800 + (ch >> 10));
+                result.push_back(jchar(0xD800 + (ch >> 10)));
                 ch = wchar_t(0xDC00) + (ch & 0x03FF);
             }
 
-            result += jchar(ch);
+            result.push_back(jchar(ch));
         }
 
         return result;
@@ -574,7 +575,7 @@ namespace jni
         jobject handle = env->NewString((const jchar*) value.c_str(), jsize(value.length()));
 #else
         auto jstr = toJString(value.c_str(), value.length());
-        jobject handle = env->NewString(jstr.c_str(), jsize(jstr.length()));
+        jobject handle = env->NewString(jstr.data(), jsize(jstr.size()));
 #endif
         env->SetObjectField(_handle, field, handle);
         env->DeleteLocalRef(handle);
@@ -587,7 +588,7 @@ namespace jni
         jobject handle = env->NewString((const jchar*) value, jsize(std::wcslen(value)));
 #else
         auto jstr = toJString(value, std::wcslen(value));
-        jobject handle = env->NewString(jstr.c_str(), jsize(jstr.length()));
+        jobject handle = env->NewString(jstr.data(), jsize(jstr.size()));
 #endif
         env->SetObjectField(_handle, field, handle);
         env->DeleteLocalRef(handle);
@@ -871,7 +872,7 @@ namespace jni
         jobject handle = env->NewString((const jchar*) value.c_str(), jsize(value.length()));
 #else
         auto jstr = toJString(value.c_str(), value.length());
-        jobject handle = env->NewString(jstr.c_str(), jsize(jstr.length()));
+        jobject handle = env->NewString(jstr.data(), jsize(jstr.size()));
 #endif
         env->SetStaticObjectField(getHandle(), field, handle);
         env->DeleteLocalRef(handle);
@@ -1277,7 +1278,7 @@ namespace jni
         jobject jvalue = env->NewString((const jchar*) value.c_str(), jsize(value.length()));
 #else
         auto jstr = toJString(value.c_str(), value.length());
-        jobject jvalue = env->NewString(jstr.c_str(), jsize(jstr.length()));
+        jobject jvalue = env->NewString(jstr.data(), jsize(jstr.size()));
 #endif
         env->SetObjectArrayElement(jobjectArray(getHandle()), index, jvalue);
         env->DeleteLocalRef(jvalue);
@@ -1522,7 +1523,7 @@ namespace jni
     JNIEnv* env();
 
 #ifndef _WIN32
-    extern std::basic_string<jchar> toJString(const wchar_t* str, size_t length);
+    extern std::vector<jchar> toJString(const wchar_t* str, size_t length);
 #endif
 
     namespace internal
@@ -1603,13 +1604,13 @@ namespace jni
         void valueArg(value_t* v, const std::wstring& a)
         {
             auto jstr = toJString(a.c_str(), a.length());
-            ((jvalue*) v)->l = env()->NewString(jstr.c_str(), jsize(jstr.length()));
+            ((jvalue*) v)->l = env()->NewString(jstr.data(), jsize(jstr.size()));
         }
 
         void valueArg(value_t* v, const wchar_t* a)
         {
             auto jstr = toJString(a, std::wcslen(a));
-            ((jvalue*) v)->l = env()->NewString(jstr.c_str(), jsize(jstr.length()));
+            ((jvalue*) v)->l = env()->NewString(jstr.data(), jsize(jstr.size()));
         }
 
 #endif


### PR DESCRIPTION
libc++ is removing basic_string<> support for types that aren't char, wchar_t, char8_t, char16_t, char32_t since they aren't part of the standard (https://reviews.llvm.org/D157058).

jchar is `unsigned short` on non-Windows, so basic_string<jchar> no longer exists. Luckily, nothing depends on the result of toJString() being \0-terminated, so just use a vector<jchar> instead.

No behavior change.