### PR TITLE
Use c++11 for jnipp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(
   jnipp
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${JNI_INCLUDE_DIRS})
+target_compile_features(jnipp PUBLIC cxx_std_11)
 target_link_libraries(jnipp PUBLIC ${CMAKE_DL_LIBS})
 
 add_subdirectory(tests)


### PR DESCRIPTION
Hit an issue when trying to set up a CI build with this. Just a build system change.