### PR TITLE
Fix a throwing constructor to avoid apps being shut down.

### DIFF
--- a/changes/fixes/pr.48.md
+++ b/changes/fixes/pr.48.md
@@ -1,0 +1,1 @@
+Do not allow exceptions to escape destructors.

--- a/jnipp.cpp
+++ b/jnipp.cpp
@@ -307,9 +307,15 @@ namespace jni
 
     Object::~Object() noexcept
     {
-        JNIEnv* env = jni::env();
+        JNIEnv* env;
+        try {
+            env = jni::env();
+        } catch (const jni::InitializationException &) {
+            // Better be empty. Cannot do anything useful.
+            return;
+        }
 
-        if (_isGlobal)
+        if (_isGlobal && _handle != nullptr)
             env->DeleteGlobalRef(_handle);
 
         if (_class != nullptr)

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -203,6 +203,11 @@ TEST(Class_call_staticMethod_byName)
     jni::Object Tests
  */
 
+// Must run before loading JVM
+TEST(Object_noDestructorException)
+{
+    jni::Object o;
+}
 
 TEST(Object_defaultConstructor_isNull)
 {
@@ -574,6 +579,9 @@ TEST(Arg_ObjectPtr)
 
 int main()
 {
+    // Tests that depend on having no JVM
+    RUN_TEST(Object_noDestructorException);
+
     // jni::Vm Tests
     RUN_TEST(Vm_detectsJreInstall);
     RUN_TEST(Vm_notAllowedMultipleVms);


### PR DESCRIPTION
This was a crasher in Monado.

Now has a test, which correctly fails before the fix commit