### PR TITLE
Add stdlib include to jnipp.cpp

### DIFF
--- a/jnipp.cpp
+++ b/jnipp.cpp
@@ -8,6 +8,7 @@
 # include <dlfcn.h>
 # include <unistd.h>
 # include <tuple>
+# include <stdlib.h>
 #endif
 
 // External Dependencies
@@ -665,7 +666,7 @@ namespace jni
         return Class(getClass(), Temporary).getField(name, signature);
     }
 
-    jobject Object::makeLocalReference() const 
+    jobject Object::makeLocalReference() const
     {
         if (isNull())
             return nullptr;


### PR DESCRIPTION
Build errors were detected in Chromium due to a missing stdlib include during the latest cxx roll (see https://crbug.com/376296990). This adds the missing dependency.